### PR TITLE
Erstatt exception med warning for manglende fortsattArbeidssoker

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/SykepengesoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/SykepengesoknadService.kt
@@ -139,11 +139,11 @@ class SykepengesoknadService(
         val erAvsluttendeSoknad = arbeidssokerperiode.vedtaksperiodeTom.isEqual(soknad.tom)
 
         if (!erAvsluttendeSoknad && soknad.fortsattArbeidssoker == null) {
-            throw PeriodebekreftelseException(
-                "Mangler verdi for fortsattArbeidssoker i søknad: ${soknad.id} med " +
-                    "vedtaksperiode: ${soknad.friskTilArbeidVedtakId} og " +
-                    "arbeidssokerperiode: ${arbeidssokerperiode.id} som skal være satt da søknaden " +
-                    "ikke er siste i perioden.",
+            log.warn(
+                "Mangler verdi for fortsattArbeidssoker i søknad: ${soknad.id} med soknad.tom: ${soknad.tom}, " +
+                    "vedtaksperiode: ${soknad.friskTilArbeidVedtakId} og arbeidssokerperiode: ${arbeidssokerperiode.id} " +
+                    "med vedtaksperiode.tom: ${{ arbeidssokerperiode.vedtaksperiodeTom }}. Verdien skal kun mangle på " +
+                    "siste søknad i perioden, men dette kan endre seg ved korrigeriner av perioden.",
             )
         }
 

--- a/src/test/kotlin/no/nav/helse/flex/sykepengesoknad/PeriodebekreftelseIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/sykepengesoknad/PeriodebekreftelseIntegrationTest.kt
@@ -144,20 +144,6 @@ class PeriodebekreftelseIntegrationTest : FellesTestOppsett() {
     }
 
     @Test
-    fun `Søknad som ikke er siste søknad og mangler verdi for fortsattArbeidssoker feiler`() {
-        lagreArbeidssokerperiode()
-
-        val soknad =
-            lagSendtSoknad(fortsattArbeidssoker = true, inntektUnderveis = false).copy(fortsattArbeidssoker = null)
-
-        assertThrows<PeriodebekreftelseException> {
-            sykepengesoknadService.behandleSoknad(soknad)
-        }
-
-        periodebekreftelseRepository.findAll().toList().size `should be equal to` 0
-    }
-
-    @Test
     fun `Søknad hvor bruker ikke har fått svart på inntektUnderveis`() {
         lagreArbeidssokerperiode()
 


### PR DESCRIPTION
Sjekken introduserer for ofte feil ved korrigering av periode etter at søknaden er aktivert.
