### PR TITLE
Refaktorer bort Any til fordel for generics

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
@@ -110,8 +110,10 @@ class KafkaConfig(
     // Navngir for å hjelpe Spring med mathcing siden vi bruker Generics.
     @Bean("avroKafkaListenerContainerFactory")
     @ConditionalOnMissingBean(name = ["avroKafkaListenerContainerFactory"])
-    fun <T> avroKafkaListenerContainerFactory(kafkaErrorHandler: KafkaErrorHandler) =
-        ConcurrentKafkaListenerContainerFactory<Long, Any>().also {
+    fun <T : Any> avroKafkaListenerContainerFactory(
+        kafkaErrorHandler: KafkaErrorHandler,
+    ): ConcurrentKafkaListenerContainerFactory<Long, T> =
+        ConcurrentKafkaListenerContainerFactory<Long, T>().also {
             val consumerConfig =
                 mapOf(
                     ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to LongDeserializer::class.java,

--- a/src/test/kotlin/no/nav/helse/flex/kafka/TestKafkaConfig.kt
+++ b/src/test/kotlin/no/nav/helse/flex/kafka/TestKafkaConfig.kt
@@ -139,20 +139,21 @@ class TestKafkaConfig(
 
     // Erstatter ConcurrentKafkaListenerContainerFactory i klassene som testes sånn at MockSchemaRegistryClient brukes.
     @Bean("avroKafkaListenerContainerFactory")
-    fun avroKafkaListenerContainerFactory(
+    fun <T : Any> avroKafkaListenerContainerFactory(
         kafkaErrorHandler: KafkaErrorHandler,
         mockSchemaRegistryClient: MockSchemaRegistryClient,
-    ) = ConcurrentKafkaListenerContainerFactory<Long, Any>().also {
-        it.setConsumerFactory(
-            DefaultKafkaConsumerFactory(
-                lagAvroDeserializerConfig(),
-                LongDeserializer(),
-                KafkaAvroDeserializer(mockSchemaRegistryClient) as Deserializer<Any>,
-            ),
-        )
-        it.setCommonErrorHandler(kafkaErrorHandler)
-        it.containerProperties.ackMode = AckMode.MANUAL_IMMEDIATE
-    }
+    ): ConcurrentKafkaListenerContainerFactory<Long, T> =
+        ConcurrentKafkaListenerContainerFactory<Long, T>().also {
+            it.setConsumerFactory(
+                DefaultKafkaConsumerFactory(
+                    lagAvroDeserializerConfig(),
+                    LongDeserializer(),
+                    KafkaAvroDeserializer(mockSchemaRegistryClient) as Deserializer<T>,
+                ),
+            )
+            it.setCommonErrorHandler(kafkaErrorHandler)
+            it.containerProperties.ackMode = AckMode.MANUAL_IMMEDIATE
+        }
 
     private fun lagConsumer(groupId: String): Consumer<String, String> =
         DefaultKafkaConsumerFactory(


### PR DESCRIPTION
Ryddet litt, men <T : Any> er nødvendig for å sikre at payload-typen ikke kan være
null, sånn at den er kompatibel med Kafka/Avro-serialisering.
